### PR TITLE
Support for Laravel 9.x

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,7 +1,6 @@
 name: phpunit
 
-on:
-  push:
+on: [ push, pull_request ]
 
 jobs:
   phpunit:

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,6 @@
         }
     },
     "require": {
-        "laravel/framework": "^6.20.12|^7.24|^8.0"
+        "laravel/framework": "^6.20.12|^7.24|^8.0|^9.0"
     }
 }

--- a/src/Providers/CommandServiceProvider.php
+++ b/src/Providers/CommandServiceProvider.php
@@ -20,7 +20,7 @@ class CommandServiceProvider extends ServiceProvider
 
     protected function langPath(string $lang): string
     {
-      if ((int) substr(app()->version(), 1) < 9) {
+      if ((int) substr(app()->version(), 0 , 1) >= 9) {
         return app()->langPath($lang);
       }
 

--- a/src/Providers/CommandServiceProvider.php
+++ b/src/Providers/CommandServiceProvider.php
@@ -18,6 +18,15 @@ class CommandServiceProvider extends ServiceProvider
 {
     protected $defer = true;
 
+    protected function langPath(string $lang): string
+    {
+      if ((int) substr(app()->version(), 1) < 9) {
+        return app()->langPath($lang);
+      }
+
+      return resource_path(sprintf('lang/%s', $lang));
+    }
+
     public function boot()
     {
         $this->registerCommands();
@@ -30,9 +39,9 @@ class CommandServiceProvider extends ServiceProvider
 
         $this->publishes([
             sprintf('%s/%s/%s', __DIR__, '../Resources/lang', $lang) =>
-                resource_path(sprintf('lang/%s', $lang)),
+                $this->langPath($lang),
             sprintf('%s/%s/%s.json', __DIR__, '../Resources/lang', $lang) =>
-                resource_path(sprintf('lang/%s.json', $lang)),
+                $this->langPath(sprintf('%s.json', $lang)),
         ]);
     }
 


### PR DESCRIPTION
## Resolved Issues
- close #1

## Details of Changes
* Both Laravel 9.x and later or earlier versions can now place language files in the appropriate directories.
* Laravel 9.x and later uses `app()->langPath()`, which is a smart way to get the path. However, if `resources/lang` is present in 9.x or later, this path takes precedence.
* Not all PullRequests are necessarily good. Here, all PullRequests are automatically tested when they are created.