### PR TITLE
fix: Major version acquisition logic

### DIFF
--- a/src/Providers/CommandServiceProvider.php
+++ b/src/Providers/CommandServiceProvider.php
@@ -20,7 +20,7 @@ class CommandServiceProvider extends ServiceProvider
 
     protected function langPath(string $lang): string
     {
-      if ((int) substr(app()->version(), 0 , 1) >= 9) {
+      if ((int) explode('.', app()->version())[0] >= 9) {
         return app()->langPath($lang);
       }
 


### PR DESCRIPTION
I Fixed error when retrieving major version of Laravel 10 or later.

```PHP
$version = '10.0.0';

# 🔥 It doesn't work well
echo substr($version, 0 , 1); // Output is "1"

# ✅ This correction
echo explode('.', $version)[0]; // Output is "10"
```

